### PR TITLE
为流动性挖矿下单提供类似IOC（下单即撤）模式 

### DIFF
--- a/vnpy/app/algo_trading/algos/liquid_mining_algo.py
+++ b/vnpy/app/algo_trading/algos/liquid_mining_algo.py
@@ -125,7 +125,10 @@ class LiquidMiningAlgo(AlgoTemplate):
         if self.vt_ask_orderid != "":
             self.ask_order_alive_tick += 1
             # if time to kill
-            cancel_ask = self.enable_ioc and self.ask_order_alive_tick > self.ioc_intervel
+            cancel_ask = False
+            if self.enable_ioc and self.ask_order_alive_tick > self.ioc_intervel:
+                self.write_log(f"当前卖单保持时间{self.ask_order_alive_tick} 超过 {self.ioc_intervel}")
+                cancel_ask = True
             if not cancel_ask:
                 # if price check fail
                 min_ask_price = getattr(tick, f"ask_price_{self.min_order_level - 1}") if self.min_order_level > 1 else market_price
@@ -145,7 +148,10 @@ class LiquidMiningAlgo(AlgoTemplate):
         if self.vt_bid_orderid != "":
             self.bid_order_alive_tick += 1
             # if time to kill
-            cancel_bid = self.enable_ioc and self.bid_order_alive_tick > self.ioc_intervel
+            cancel_bid = False
+            if self.enable_ioc and self.bid_order_alive_tick > self.ioc_intervel:
+                self.write_log(f"当前买单保持时间{self.ask_order_alive_tick} 超过 {self.ioc_intervel}")
+                cancel_bid = True
             if not cancel_bid:
                 # if price check fail
                 max_bid_price = getattr(tick, f"bid_price_{self.min_order_level - 1}") if self.min_order_level > 1 else market_price
@@ -157,6 +163,7 @@ class LiquidMiningAlgo(AlgoTemplate):
                 if self.vt_bid_price > max_bid_price:
                     cancel_bid = True
                     self.write_log(f"当前买单{self.vt_bid_price} 高于最高买{self.min_order_level}价 {max_bid_price:.3f}，取消")
+
             if cancel_bid:
                 self.cancel_order(self.vt_bid_orderid)
                 # self.bid_order_alive_tick = 0
@@ -221,8 +228,10 @@ class LiquidMiningAlgo(AlgoTemplate):
     def on_trade(self, trade: TradeData):
         """"""
         if trade.direction == Direction.SHORT:
+            self.write_log(f"流动性挖矿卖出成交，价:{trade.price}, 量:{trade.volume}")
             self.pos -= trade.volume
         elif trade.direction == Direction.LONG:
+            self.write_log(f"流动性挖矿买入成交，价:{trade.price}, 量:{trade.volume}")
             self.pos += trade.volume
 
         self.put_variables_event()

--- a/vnpy/app/algo_trading/algos/liquid_mining_algo.py
+++ b/vnpy/app/algo_trading/algos/liquid_mining_algo.py
@@ -220,9 +220,9 @@ class LiquidMiningAlgo(AlgoTemplate):
 
     def on_trade(self, trade: TradeData):
         """"""
-        if trade.tradeid == self.vt_ask_orderid:
+        if trade.direction == Direction.SHORT:
             self.pos -= trade.volume
-        elif trade.tradeid == self.vt_bid_orderid:
+        elif trade.direction == Direction.LONG:
             self.pos += trade.volume
 
         self.put_variables_event()

--- a/vnpy/app/algo_trading/algos/liquid_mining_algo.py
+++ b/vnpy/app/algo_trading/algos/liquid_mining_algo.py
@@ -59,7 +59,7 @@ class LiquidMiningAlgo(AlgoTemplate):
         self.min_pos            = setting["min_pos"]
         self.max_pos            = setting["max_pos"]
         self.enable_ioc         = setting.get("enable_ioc", False)
-        self.ioc_intervel       = setting.get("ioc_intervel", self.interval)
+        self.ioc_intervel       = setting.get("ioc_interval", self.interval)
 
         # validate setting
         assert self.price_tolerance <= self.price_offset
@@ -150,7 +150,7 @@ class LiquidMiningAlgo(AlgoTemplate):
             # if time to kill
             cancel_bid = False
             if self.enable_ioc and self.bid_order_alive_tick > self.ioc_intervel:
-                self.write_log(f"当前买单保持时间{self.ask_order_alive_tick} 超过 {self.ioc_intervel}")
+                self.write_log(f"当前买单保持时间{self.bid_order_alive_tick} 超过 {self.ioc_intervel}")
                 cancel_bid = True
             if not cancel_bid:
                 # if price check fail

--- a/vnpy/app/algo_trading/algos/liquid_mining_algo.py
+++ b/vnpy/app/algo_trading/algos/liquid_mining_algo.py
@@ -127,7 +127,7 @@ class LiquidMiningAlgo(AlgoTemplate):
             # if time to kill
             cancel_ask = False
             if self.enable_ioc and self.ask_order_alive_tick > self.ioc_intervel:
-                self.write_log(f"当前卖单保持时间{self.ask_order_alive_tick} 超过 {self.ioc_intervel}")
+                self.write_log(f"卖单{self.vt_ask_orderid}有效时间{self.ask_order_alive_tick} ticks > {self.ioc_intervel},取消")
                 cancel_ask = True
             if not cancel_ask:
                 # if price check fail
@@ -136,10 +136,10 @@ class LiquidMiningAlgo(AlgoTemplate):
                 ask_price_diff = 100 * abs(self.vt_ask_price - target_ask_price) / target_ask_price
                 if ask_price_diff > price_tolerance:
                     cancel_ask = True
-                    self.write_log(f"当前卖单{self.vt_ask_price} 超出目标价 {target_ask_price} {ask_price_diff:.3f}%，取消")
+                    self.write_log(f"卖单{self.vt_ask_orderid}价{self.vt_ask_price}超出目标价 {target_ask_price} {ask_price_diff:.3f}%,取消")
                 if self.vt_ask_price < min_ask_price:
                     cancel_ask = True
-                    self.write_log(f"当前卖单{self.vt_ask_price} 低于最低卖{self.min_order_level}价 {min_ask_price:.3f}，取消")
+                    self.write_log(f"卖单{self.vt_ask_orderid}价{self.vt_ask_price}低于最低卖{self.min_order_level}价 {min_ask_price:.3f},取消")
 
             if cancel_ask:
                 self.cancel_order(self.vt_ask_orderid)
@@ -150,7 +150,7 @@ class LiquidMiningAlgo(AlgoTemplate):
             # if time to kill
             cancel_bid = False
             if self.enable_ioc and self.bid_order_alive_tick > self.ioc_intervel:
-                self.write_log(f"当前买单保持时间{self.bid_order_alive_tick} 超过 {self.ioc_intervel}")
+                self.write_log(f"买单{self.vt_bid_orderid}有效时间{self.bid_order_alive_tick} ticks > {self.ioc_intervel},取消")
                 cancel_bid = True
             if not cancel_bid:
                 # if price check fail
@@ -159,10 +159,10 @@ class LiquidMiningAlgo(AlgoTemplate):
                 bid_price_diff = 100 * abs(self.vt_bid_price - target_bid_price) / target_bid_price
                 if bid_price_diff > price_tolerance:
                     cancel_bid = True
-                    self.write_log(f"当前买单{self.vt_bid_price} 超出目标价 {target_bid_price} {bid_price_diff:.3f}%，取消")
+                    self.write_log(f"买单{self.vt_bid_orderid}价{self.vt_bid_price} 超出目标价 {target_bid_price} {bid_price_diff:.3f}%,取消")
                 if self.vt_bid_price > max_bid_price:
                     cancel_bid = True
-                    self.write_log(f"当前买单{self.vt_bid_price} 高于最高买{self.min_order_level}价 {max_bid_price:.3f}，取消")
+                    self.write_log(f"买单{self.vt_bid_orderid}价{self.vt_bid_price} 高于最高买{self.min_order_level}价 {max_bid_price:.3f},取消")
 
             if cancel_bid:
                 self.cancel_order(self.vt_bid_orderid)
@@ -228,10 +228,10 @@ class LiquidMiningAlgo(AlgoTemplate):
     def on_trade(self, trade: TradeData):
         """"""
         if trade.direction == Direction.SHORT:
-            self.write_log(f"流动性挖矿卖出成交，价:{trade.price}, 量:{trade.volume}")
+            self.write_log(f"流动性挖矿卖单{trade.vt_orderid}成交，价:{trade.price}, 量:{trade.volume}")
             self.pos -= trade.volume
         elif trade.direction == Direction.LONG:
-            self.write_log(f"流动性挖矿买入成交，价:{trade.price}, 量:{trade.volume}")
+            self.write_log(f"流动性挖矿买单{trade.vt_orderid}成交，价:{trade.price}, 量:{trade.volume}")
             self.pos += trade.volume
 
         self.put_variables_event()

--- a/vnpy/gateway/loopring/loopring_gateway.py
+++ b/vnpy/gateway/loopring/loopring_gateway.py
@@ -693,6 +693,7 @@ class LoopringRestApi(RestClient):
 
         tokenId = request.params['tokenSId']
         self.orderId_manager.put_orderId(tokenId, int(data['data']))
+        self.gateway.write_log("账户token{tokenId} orderId查询成功")
 
     def on_query_orders(self, data, request):
         # self.gateway.write_log(f"on_query_orders {data}")

--- a/vnpy/gateway/loopring/loopring_gateway.py
+++ b/vnpy/gateway/loopring/loopring_gateway.py
@@ -661,7 +661,7 @@ class LoopringRestApi(RestClient):
         self.query_orders()
 
     def on_query_balance(self, data, request):
-        self.gateway.write_log(f"on_query_balance {data}")
+        # self.gateway.write_log(f"on_query_balance {data}")
         if data['resultInfo']['code'] != 0:
             raise AttributeError(f"on_query_balance failed {data}")
 
@@ -687,7 +687,7 @@ class LoopringRestApi(RestClient):
         self.gateway.write_log("账户余额查询成功")
 
     def on_query_orderId(self, data, request):
-        self.gateway.write_log(f"on_query_orderId {request} {data}")
+        # self.gateway.write_log(f"on_query_orderId {request} {data}")
         if data['resultInfo']['code'] != 0:
             raise AttributeError(f"on_query_orderId failed {data}")
 
@@ -695,8 +695,8 @@ class LoopringRestApi(RestClient):
         self.orderId_manager.put_orderId(tokenId, int(data['data']))
 
     def on_query_orders(self, data, request):
-        self.gateway.write_log(f"on_query_orders {data}")
-
+        # self.gateway.write_log(f"on_query_orders {data}")
+        orders = []
         for order in data['data']['orders']:
             # TODO: use correct decimals to calc volume
             decimals = self.contracts[order['market']].decimals
@@ -713,9 +713,9 @@ class LoopringRestApi(RestClient):
                 datetime=datetime.fromtimestamp(float(order['createdAt']) / 1000).__str__(),
                 gateway_name=self.gateway_name,
             )
+            orders.append(order_data)
             self.gateway.on_order(order_data)
-
-        self.gateway.write_log("所有Orders查询成功")
+        self.gateway.write_log(f"所有Orders查询成功:\n{orders}")
 
     def on_query_token(self, data, request):
         """"""
@@ -784,7 +784,7 @@ class LoopringRestApi(RestClient):
             self.gateway.on_order(order)
             return
 
-        self.gateway.write_log(f"下单 {request.data} 成功")
+        self.gateway.write_log(f"下单 {request.extra[0]} 成功, hash = {data['data']}.")
         order = request.extra[0]
         order.status = Status.NOTTRADED
         self.gateway.on_order(order)
@@ -827,7 +827,7 @@ class LoopringRestApi(RestClient):
             sleep(0.15)
 
     def on_error_recover_orderId(self, request, newest_order_id: int = 0):
-        self.gateway.write_log(f"on_error_recover_orderId: {request} {newest_order_id}")
+        # self.gateway.write_log(f"on_error_recover_orderId: {request} {newest_order_id}")
         order_detail = ujson.loads(request.data)
         orderId = order_detail.get('orderId', None)
         tokenSId = order_detail.get('tokenSId', None)

--- a/vnpy/gateway/loopring/loopring_gateway.py
+++ b/vnpy/gateway/loopring/loopring_gateway.py
@@ -768,6 +768,7 @@ class LoopringRestApi(RestClient):
 
     def on_send_order(self, data, request):
         if data['resultInfo']['code'] != 0:
+            self.gateway.write_log(f"下单 {request.extra[0]} 失败, 原因:{data['resultInfo']['message']}.")
             order = request.extra[0]
             order.status = Status.REJECTED
             # {'error': {'code': 102007, 'message': 'order existed, please check detail order info'}}


### PR DESCRIPTION
Config里面新增两个参数：

```python
    "enable_ioc": True,
    "ioc_interval": 3
```

enable_ioc: 启动下单即撤模式。
ioc_interval: 下单即撤保持时间，目前是tick数，一个tick大约2s。

之前Config里面已经存在一个interval，那个是下单周期，所以在正常的IOC模式下，订单会经历这样的模式：

![image](https://user-images.githubusercontent.com/26989346/95168078-516cfd80-07e3-11eb-8e75-9f330f53443c.png)

推荐配置
```python
ioc_interval: 3 # 大约6s
interval: 7 # >=6s
```